### PR TITLE
fix(docs): 修复环境变量icon的前缀拼写

### DIFF
--- a/src/guide/icon/usage.md
+++ b/src/guide/icon/usage.md
@@ -18,7 +18,7 @@
     ```
 
     ::: tip Tip
-    'icon-' is a preset prefix, set the variable VITE_ICON_PREFFIX in .env
+    'icon-' is a preset prefix, set the variable VITE_ICON_PREFIX in .env
     :::
 
   - Set the style: Apply the style attribute or class attribute directly like the html tag; set the corresponding color and size by setting the color and font-size attributes
@@ -34,7 +34,7 @@
     ```
 
     ::: tip Tip
-    'icon-local' is a preset prefix, set the variable VITE_ICON_LOCAL_PREFFIX in .env
+    'icon-local' is a preset prefix, set the variable VITE_ICON_LOCAL_PREFIX in .env
     :::
 
 

--- a/src/zh/guide/icon/usage.md
+++ b/src/zh/guide/icon/usage.md
@@ -18,7 +18,7 @@
     ```
 
     ::: tip 提示
-    'icon-' 为预设的前缀, 在.env 里面设置变量 VITE_ICON_PREFFIX
+    'icon-' 为预设的前缀, 在.env 里面设置变量 VITE_ICON_PREFIX
     :::
 
   - 设置样式：同 html 标签一样直接应用 style 属性或者 class 属性; 通过设置 color 和 font-size 属性设置对应的颜色和大小
@@ -34,7 +34,7 @@
     ```
 
     ::: tip 提示
-    'icon-local' 为预设的前缀, 在.env 里面设置变量 VITE_ICON_LOCAL_PREFFIX
+    'icon-local' 为预设的前缀, 在.env 里面设置变量 VITE_ICON_LOCAL_PREFIX
     :::
 
 ## 二、动态渲染: 根据图标名称渲染对应图标


### PR DESCRIPTION
修复文档中icon前缀的拼写
路径：系统图标-使用
VITE_ICON_PREFFIX -> VITE_ICON_PREFIX
VITE_ICON_LOCAL_PREFFIX -> VITE_ICON_LOCAL_PREFIX